### PR TITLE
don't require changes to config file to add networks

### DIFF
--- a/events.gs
+++ b/events.gs
@@ -3,15 +3,12 @@
 
 function onEdit (evt) {
   var sheet = SpreadsheetApp.getActiveSheet()
-  var sheetName = sheet.getName()
-  for (var key in config.networks) {
-    var network = config.networks[key]
-    if (network.nodes === sheetName) {
-      evt.sheet = sheet
-      onnodeChange(evt)
-      break
-    }
-  }
+  var keys = getKeys(sheet).indexesByKey
+  if (keys.location === undefined) return
+  if (keys.latitude === undefined) return
+  if (keys.longitude === undefined) return
+  evt.sheet = sheet
+  onnodeChange(evt)
 }
 
 function onnodeChange (evt) {

--- a/http-api.gs
+++ b/http-api.gs
@@ -3,7 +3,18 @@ var httpApi = {
     GET: function (req) {
       var spreadsheet = SpreadsheetApp.getActiveSpreadsheet()
       var networkId = req.parameter.network
-      var network = config.networks[networkId || '_default_']
+      var network = null
+      if (networkId) {
+        network = config.networks[networkId]
+        if (!network) {
+          network = {
+            nodes: networkId,
+            links: networkId + '-links'
+          }
+        }
+      } else {
+        network = config.networks._default_
+      }
       var nodes = getObjects(
         spreadsheet.getSheetByName(network.nodes),
         req.parameter.limit,


### PR DESCRIPTION
@bhny this should make it possible to add new networks without changing the config.gs file or publishing a new script version.

You will need to pass the network name as the `network` parameter to the HTTP endpoint and your links tab must use the same exact name suffixed with "-links".

Create kml files like so:
``` xml
<NetworkLink>      
  <name>NYC Mesh - NETWORKNAME</name>                 
  <flyToView>0</flyToView>             
  <Link>      
  <href>https://script.google.com/macros/s/AKfycbw4WgfR01CLqZcTtQi_5o7l6GXTPKJs4ep2Tpw7TdeH-uqRiuY/exec?method=geography&amp;network=NETWORKNAME&amp;format=kml</href>
    <viewRefreshMode>onRequest</viewRefreshMode>                              
  </Link>          
</NetworkLink>
```